### PR TITLE
Added mentions to new issues page

### DIFF
--- a/lib/redmine_mentions/hooks.rb
+++ b/lib/redmine_mentions/hooks.rb
@@ -9,5 +9,7 @@ module RedmineMentions
     #   :f      => the form object to create additional fields
     render_on :view_issues_edit_notes_bottom,
               :partial => 'hooks/redmine_mentions/edit_mentionable'
+    render_on :view_issues_form_details_bottom,
+              :partial => 'hooks/redmine_mentions/edit_mentionable'
   end
 end


### PR DESCRIPTION
This makes the mentions dropdown appear in the `New Issue` page `Description` filed ( as a completion for 1c42c4db547d17122c979c256a045199800ba75f)
