### PR TITLE
Updated view and journal_patch to force AR association to array for delete_if method to work.

### DIFF
--- a/app/views/hooks/redmine_mentions/_edit_mentionable.html.erb
+++ b/app/views/hooks/redmine_mentions/_edit_mentionable.html.erb
@@ -4,7 +4,7 @@
 <% regex_find = '/\B'+Setting.plugin_redmine_mentions['trigger']+'(\w*)$/i'%>
 
 
-<%users= @project.users.delete_if{|u| (u.type != 'User' || u.mail.empty?)}%>
+<%users= @project.users.to_a.delete_if{|u| (u.type != 'User' || u.mail.empty?)}%>
 <%users_regex=users.collect{|u| "#{Setting.plugin_redmine_mentions['trigger']}#{u.login}"}.join('|')%>
 <% regex_highlight = '/\B('+users_regex+')/g' %>
 <script>

--- a/lib/redmine_mentions/journal_patch.rb
+++ b/lib/redmine_mentions/journal_patch.rb
@@ -8,7 +8,7 @@ module RedmineMentions
           if self.journalized.is_a?(Issue) && self.notes.present?
             issue = self.journalized
             project=self.journalized.project
-            users=project.users.delete_if{|u| (u.type != 'User' || u.mail.empty?)}
+            users=project.users.to_a.delete_if{|u| (u.type != 'User' || u.mail.empty?)}
             users_regex=users.collect{|u| "#{Setting.plugin_redmine_mentions['trigger']}#{u.login}"}.join('|')
             regex_for_email = '\B('+users_regex+')'
             regex = Regexp.new(regex_for_email)


### PR DESCRIPTION
I was running into issues with getting a `NoMethodError delete_if for ActiveRecord...`, where basically this was calling `delete_if` on an AR association instead of on an array (which I assume is what was meant).

This allows the plugin to work on the latest Redmine running Rails 4.