### PR TITLE
enable search in words, fix uppercase user match

### DIFF
--- a/app/views/hooks/redmine_mentions/_edit_mentionable.html.erb
+++ b/app/views/hooks/redmine_mentions/_edit_mentionable.html.erb
@@ -10,11 +10,11 @@
 <script>
   $('#issue_notes,#issue_description').textcomplete([
     {
-      mentions: <%=  users.collect{|u| "#{u.firstname} #{u.lastname} - <small>#{u.login}</small>".downcase}.to_json.html_safe %>,
+      mentions: <%=  users.collect{|u| "#{u.firstname} #{u.lastname} - <small>#{u.login}</small>"}.to_json.html_safe %>,
       match: <%=regex_find%>,
       search: function(term, callback) {
         callback($.map(this.mentions, function(mention) {
-          return mention.indexOf(term) === 0 ? mention : null;
+          return mention.toLowerCase().indexOf(term) !== -1 ? mention : null;
         }));
       },
       index: 1,


### PR DESCRIPTION
* enable search in user name, not search from the beginning of the words.

* fix #19  uppercase user match

return the original user names instead of downcase them.

* use lowercase to match both lowercase and uppercase

e.g. if you type jasonz, it will try to match *jasonz*, *JASONZ*, *jasonZ*, etc.