### PR TITLE
Also match ending word boundary of mention

### DIFF
--- a/lib/redmine_mentions/journal_patch.rb
+++ b/lib/redmine_mentions/journal_patch.rb
@@ -10,7 +10,7 @@ module RedmineMentions
             project=self.journalized.project
             users=project.users.to_a.delete_if{|u| (u.type != 'User' || u.mail.empty?)}
             users_regex=users.collect{|u| "#{Setting.plugin_redmine_mentions['trigger']}#{u.login}"}.join('|')
-            regex_for_email = '\B('+users_regex+')'
+            regex_for_email = '\B('+users_regex+')\b'
             regex = Regexp.new(regex_for_email)
             mentioned_users = self.notes.scan(regex)
             mentioned_users.each do |mentioned_user|


### PR DESCRIPTION
This will fix #10 

In the example the following regex would have been used in the code

    \B(@ted|@ted123)

Since regex is greedy it would match @ted before it would match @ted123.
Therefore I added \b to indicate the ending word boundary. Thus

    \B(@ted|@ted123)\b