### PR TITLE
CKEditor workaround

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -8,9 +8,9 @@ end
 Redmine::Plugin.register :redmine_mentions do
   name 'Redmine Mentions'
   author 'Arkhitech'
-  description 'This is a plugin for Redmine which gives suggestions on using username in comments'
+  description 'This is a plugin for Redmine which gives suggestions on using username in comments. Was modified to stop killing CKEditor.'
   version '0.0.1'
-  url 'https://github.com/arkhitech/redmine_mentions'
+  url 'https://github.com/scrapinghub/redmine_mentions'
   author_url 'http://www.arkhitech.com/'
   settings :default => {'trigger' => '@'}, :partial => 'settings/mention'
 end

--- a/lib/redmine_mentions/hooks.rb
+++ b/lib/redmine_mentions/hooks.rb
@@ -1,15 +1,29 @@
 module RedmineMentions
-  class Hooks < Redmine::Hook::ViewListener
-    # This just renders the partial in
-    # app/views/hooks/my_plugin/_view_issues_form_details_bottom.rhtml
-    # The contents of the context hash is made available as local variables to the partial.
-    #
-    # Additional context fields
-    #   :issue  => the issue this is edited
-    #   :f      => the form object to create additional fields
-    render_on :view_issues_edit_notes_bottom,
-              :partial => 'hooks/redmine_mentions/edit_mentionable'
-    render_on :view_issues_form_details_bottom,
-              :partial => 'hooks/redmine_mentions/edit_mentionable'
-  end
+	class Hooks < Redmine::Hook::ViewListener
+		# This just renders the partial in
+		# app/views/hooks/my_plugin/_view_issues_form_details_bottom.rhtml
+		# The contents of the context hash is made available as local variables to the partial.
+		#
+		# Additional context fields
+		#   :issue  => the issue this is edited
+		#   :f      => the form object to create additional fields
+
+		def view_issues_edit_notes_bottom(context={ })
+			if ['textile', 'markdown'].include?(Setting.text_formatting)
+				context[:controller].send(:render_to_string, {
+					:partial => "hooks/redmine_mentions/edit_mentionable",
+					:locals => context
+				})
+			end
+		end
+
+		def view_issues_form_details_bottom(context={ })
+			if ['textile', 'markdown'].include?(Setting.text_formatting)
+				context[:controller].send(:render_to_string, {
+					:partial => "hooks/redmine_mentions/edit_mentionable",
+					:locals => context
+				})
+			end
+		end
+	end
 end


### PR DESCRIPTION
This plugin makes CKEditor unusable. This is a workaround to make
'mentions' work with 'textile' and 'markdown' while keeping CKEditor
clean.

This is a `ruby` solution, this can also be done via JQuery.