### PR TITLE
Highlight users apropriately

### DIFF
--- a/app/views/hooks/redmine_mentions/_edit_mentionable.html.erb
+++ b/app/views/hooks/redmine_mentions/_edit_mentionable.html.erb
@@ -9,7 +9,7 @@
   <% users = User.active.to_a.delete_if{|u| (u.type != 'User' || u.mail.empty?)}%>
 <% end %>
 <% users_regex = users.collect{|u| "#{Setting.plugin_redmine_mentions['trigger']}#{u.login}"}.join('|')%>
-<% regex_highlight = '/\B('+users_regex+')/g' %>
+<% regex_highlight = '/\B('+users_regex+')\b/g' %>
 <script>
   $('#issue_notes,#issue_description').textcomplete([
     {


### PR DESCRIPTION
If you have two users which one username is a subset of the other (ex: John and Johnson, Frank and Franklin), the highlight can be applied to the shorter name sometimes.
Fixes the regex.