### PR TITLE
Various fixes and hides user login.

### DIFF
--- a/app/models/mention_mailer.rb
+++ b/app/models/mention_mailer.rb
@@ -1,4 +1,5 @@
 class MentionMailer < ActionMailer::Base
+  include ApplicationHelper
   layout 'mailer'
   default from: Setting.mail_from
   def self.default_url_options
@@ -9,6 +10,8 @@ class MentionMailer < ActionMailer::Base
   def notify_mentioning(issue, journal, user)
     @issue = issue
     @journal = journal
+    @htmlnote = textilizable(journal.notes)
+    @textnote = ActionView::Base.full_sanitizer.sanitize(@htmlnote)
     mail(to: user.mail, subject: "[#{@issue.tracker.name} ##{@issue.id}] You were mentioned in: #{@issue.subject}")
   end
 end

--- a/app/views/hooks/redmine_mentions/_edit_mentionable.html.erb
+++ b/app/views/hooks/redmine_mentions/_edit_mentionable.html.erb
@@ -17,7 +17,7 @@
       match: <%=regex_find%>,
       search: function(term, callback) {
         callback($.map(this.mentions, function(mention) {
-          return mention.toLowerCase().indexOf(term) !== -1 ? mention : null;
+          return mention.toLowerCase().indexOf(term.toLowerCase()) !== -1 ? mention : null;
         }));
       },
       index: 1,

--- a/app/views/hooks/redmine_mentions/_edit_mentionable.html.erb
+++ b/app/views/hooks/redmine_mentions/_edit_mentionable.html.erb
@@ -8,12 +8,12 @@
 <% else %>
   <% users = User.active.to_a.delete_if{|u| (u.type != 'User' || u.mail.empty?)}%>
 <% end %>
-<% users_regex = users.collect{|u| "#{Setting.plugin_redmine_mentions['trigger']}#{u.login}"}.join('|')%>
+<% users_regex = users.collect{|u| "\"#{Regexp.escape("#{u.firstname} #{u.lastname}")}\":#{Setting.protocol}://#{Setting.host_name}#{user_path(u)}".gsub(/(["\/])/, '\\\\\1')}.join('|') %>
 <% regex_highlight = '/\B('+users_regex+')\b/g' %>
 <script>
   $('#issue_notes,#issue_description').textcomplete([
     {
-      mentions: <%=  users.collect{|u| "#{u.firstname} #{u.lastname} - <small>#{u.login}</small>"}.to_json.html_safe %>,
+      mentions: <%= users.collect{|u| "#{u.firstname} #{u.lastname}<small>#{" - " + u.mail unless u.pref.hide_mail}</small><!-- #{Setting.protocol}://#{Setting.host_name}#{user_path(u)} -->"}.to_json.html_safe %>,
       match: <%=regex_find%>,
       search: function(term, callback) {
         callback($.map(this.mentions, function(mention) {
@@ -22,14 +22,14 @@
       },
       index: 1,
       replace: function(mention) {
-        var parts = mention.split(' - ');
-        var name = parts[1].substring(parts[1].lastIndexOf("<small>")+7,parts[1].lastIndexOf("</small>"));
-        return '<%=Setting.plugin_redmine_mentions['trigger']%>' + name + ' ';
+        var name = mention.split('<small>')[0];
+        var user = mention.substring(mention.lastIndexOf("<!-- ")+5,mention.lastIndexOf(" -->"));
+        return '"' + name + '":' + user;
       }
     }
   ]).overlay([
     {
-      match: new RegExp(<%=regex_highlight%>),
+      match: new RegExp(<%=regex_highlight.html_safe%>),
       css: {
         'background-color': '#C6D5F3',
       }

--- a/app/views/mention_mailer/notify_mentioning.html.erb
+++ b/app/views/mention_mailer/notify_mentioning.html.erb
@@ -1,9 +1,6 @@
 <h4><%= link_to "[#{@issue.project.name} - #{@issue.tracker.name} ##{@issue.id}] #{@issue.subject}", issue_url(@issue) %></h4>
-
-<br /><br />
-
+<br>
 <i>You were mentioned by <strong><%= @journal.user.login %></strong> on <strong><%=  @journal.created_on.to_s(:db) %></strong></i>
-
-<br /><br />
-
-<p><%= @journal.notes %></p>
+<br><br>
+<div style="background-color: lightgrey;"><%= @htmlnote %></div>
+<br>

--- a/app/views/mention_mailer/notify_mentioning.html.erb
+++ b/app/views/mention_mailer/notify_mentioning.html.erb
@@ -1,6 +1,6 @@
 <h4><%= link_to "[#{@issue.project.name} - #{@issue.tracker.name} ##{@issue.id}] #{@issue.subject}", issue_url(@issue) %></h4>
 <br>
-<i>You were mentioned by <strong><%= @journal.user.login %></strong> on <strong><%=  @journal.created_on.to_s(:db) %></strong></i>
+<i>You were mentioned by <strong><%= "#{@journal.user.firstname} #{@journal.user.lastname}" %></strong> on <strong><%= @journal.created_on.to_s(:db) %></strong></i>
 <br><br>
 <div style="background-color: lightgrey;"><%= @htmlnote %></div>
 <br>

--- a/app/views/mention_mailer/notify_mentioning.text.erb
+++ b/app/views/mention_mailer/notify_mentioning.text.erb
@@ -1,6 +1,6 @@
 [<%= @issue.project.name %> - <%= @issue.tracker.name %> #<%= @issue.id %>] <%= @issue.subject %>
 <%= issue_url(@issue) %>
 
-You were mentioned by <%= @journal.user.login %> on <%=  @journal.created_on.to_s(:db) %>
+You were mentioned by <%= "#{@journal.user.firstname} #{@journal.user.lastname}" %> on <%= @journal.created_on.to_s(:db) %>
 
 <%= @textnote %>

--- a/app/views/mention_mailer/notify_mentioning.text.erb
+++ b/app/views/mention_mailer/notify_mentioning.text.erb
@@ -3,4 +3,4 @@
 
 You were mentioned by <%= @journal.user.login %> on <%=  @journal.created_on.to_s(:db) %>
 
-<%= @journal.notes %>
+<%= @textnote %>

--- a/assets/javascripts/jquery.overlay.js
+++ b/assets/javascripts/jquery.overlay.js
@@ -77,6 +77,8 @@
 
     css = {
       wrapper: {
+        lineHeight: '1.25em',
+        clear: 'left',
         margin: 0,
         padding: 0,
         overflow: 'hidden'
@@ -110,6 +112,7 @@
       'font-family',
       'font-weight',
       'font-size',
+      'width',
       'background-color'
     ];
 

--- a/lib/redmine_mentions/journal_patch.rb
+++ b/lib/redmine_mentions/journal_patch.rb
@@ -12,7 +12,7 @@ module RedmineMentions
             users_regex=users.collect{|u| "#{Setting.plugin_redmine_mentions['trigger']}#{u.login}"}.join('|')
             regex_for_email = '\B('+users_regex+')\b'
             regex = Regexp.new(regex_for_email)
-            mentioned_users = self.notes.scan(regex)
+            mentioned_users = self.notes.scan(regex).uniq
             mentioned_users.each do |mentioned_user|
               username = mentioned_user.first[1..-1]
               if user = User.find_by_login(username)

--- a/lib/redmine_mentions/journal_patch.rb
+++ b/lib/redmine_mentions/journal_patch.rb
@@ -9,13 +9,13 @@ module RedmineMentions
             issue = self.journalized
             project=self.journalized.project
             users=project.users.to_a.delete_if{|u| (u.type != 'User' || u.mail.empty?)}
-            users_regex=users.collect{|u| "#{Setting.plugin_redmine_mentions['trigger']}#{u.login}"}.join('|')
+            users_regex=users.collect{|u| "\"#{Regexp.escape("#{u.firstname} #{u.lastname}")}\":#{Setting.protocol}://#{Setting.host_name}#{Rails.application.routes.url_helpers.user_path(u)}".gsub(/(["\/])/, '\\\\\1')}.join('|')
             regex_for_email = '\B('+users_regex+')\b'
             regex = Regexp.new(regex_for_email)
             mentioned_users = self.notes.scan(regex).uniq
             mentioned_users.each do |mentioned_user|
-              username = mentioned_user.first[1..-1]
-              if user = User.find_by_login(username)
+              username = mentioned_user.first[1..-1].split("/").last
+              if user = User.find_by_id(username)
                 MentionMailer.notify_mentioning(issue, self, user).deliver
               end
             end


### PR DESCRIPTION
Various fixes, simplest ones first.

The last commit is to not expose user login, shows user names instead of login, so attackers wouldn't know their username. Exposes e-mail if the user set it to public. The format inside text boxes uses the wiki format to link the user to his full name, and blends nicely to the issue history.