### PR TITLE
[FIX] Allow Typing Uppercase

### DIFF
--- a/app/views/hooks/redmine_mentions/_edit_mentionable.html.erb
+++ b/app/views/hooks/redmine_mentions/_edit_mentionable.html.erb
@@ -17,7 +17,7 @@
       match: <%=regex_find%>,
       search: function(term, callback) {
         callback($.map(this.mentions, function(mention) {
-          return mention.toLowerCase().indexOf(term) !== -1 ? mention : null;
+          return mention.toLowerCase().indexOf(term.toLowerCase()) !== -1 ? mention : null;
         }));
       },
       index: 1,


### PR DESCRIPTION
When Typing a name like John Doe, it did not match John Doe.
This patch fixes this.