### PR TITLE
fix: method name called after journal is created

### DIFF
--- a/lib/redmine_mentions/journal_patch.rb
+++ b/lib/redmine_mentions/journal_patch.rb
@@ -2,9 +2,9 @@ module RedmineMentions
   module JournalPatch
     def self.included(base)
       base.class_eval do
-        after_create :send_notification
+        after_create :send_mail
         
-        def send_notification
+        def send_mail
           if self.journalized.is_a?(Issue) && self.notes.present?
             issue = self.journalized
             project=self.journalized.project


### PR DESCRIPTION
* `send_notifictation` overwrite default redmine method of Journal class
  * `send_mail` method is not defined in redmine
  * close #55 