### PR TITLE
Fix regex for autocompletion

### DIFF
--- a/app/views/hooks/redmine_mentions/_edit_mentionable.html.erb
+++ b/app/views/hooks/redmine_mentions/_edit_mentionable.html.erb
@@ -1,7 +1,7 @@
 <%= javascript_include_tag 'jquery.textcomplete.js', :plugin => 'redmine_mentions' %>
 <%= javascript_include_tag 'jquery.overlay.js', :plugin => 'redmine_mentions' %>
 <%= stylesheet_link_tag 'auto_complete.css', :plugin => 'redmine_mentions' %>
-<% regex_find = '/\B'+Setting.plugin_redmine_mentions['trigger']+'(\w*)$/i'%>
+<% regex_find = '/\B'+Setting.plugin_redmine_mentions['trigger']+'([\wа-яё\.\-]*)$/i'%>
 
 <% if @project %>
   <% users = @project.users.to_a.delete_if{|u| (u.type != 'User' || u.mail.empty?)}%>


### PR DESCRIPTION
Logins in redmine may contain not only `\w`, but also a `dot` and a `dash`: https://github.com/redmine/redmine/blob/1dcebf8/app/models/user.rb#L111

In addition, `mentions` is collected from `#{u.firstname}` and `#{u.lastname}`:
```ruby
mentions: <%=  users.collect{|u| "#{u.firstname} #{u.lastname} - <small>#{u.login}</small>"}.to_json.html_safe %>,
```

And there may be names in Russian and the autocomplete will not work when they are introduced (we encountered this particular bug in our company).

A small online test for these changes: https://regex101.com/r/kpwzOx/1

PS: Thank you very much for this wonderful plugin 👍 